### PR TITLE
Update container_resolvers_config_file option

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -104,7 +104,7 @@ galaxy_config:
     tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
     # Tool Dependencies
     dependency_resolvers_config_file: "{{ galaxy_config_dir }}/dependency_resolvers_conf.xml"
-    containers_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"
+    container_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"
     # Data Library Directories
     library_import_dir: /libraries/admin
     user_library_import_dir: /libraries/user


### PR DESCRIPTION
It seems that this config option should be renamed from `containers_resolvers_config_file` to `container_resolvers_config_file` as indicated here: https://github.com/galaxyproject/galaxy/blob/b54e7a773fbb8476c24071798f648d7305051d2c/lib/galaxy/config/sample/galaxy.yml.sample#L714